### PR TITLE
Revert "fix: convert mode permission types to u16"

### DIFF
--- a/src/services/perms.rs
+++ b/src/services/perms.rs
@@ -54,9 +54,9 @@ impl PermType {
 pub fn perms(metadata: &std::fs::Metadata, colors: &PermColors) -> String {
     let mode = metadata.permissions().mode();
 
-    let user = PermType::User.format(mode as u16, colors);
-    let group = PermType::Group.format(mode as u16, colors);
-    let other = PermType::Other.format(mode as u16, colors);
+    let user = PermType::User.format(mode, colors);
+    let group = PermType::Group.format(mode, colors);
+    let other = PermType::Other.format(mode, colors);
 
     [user, group, other].join("")
 }


### PR DESCRIPTION
Perms are already `mode_t` (aka `u32`) which is the correct type.

This reverts commit 0b12c00414009b5d3af1cfae30b1af785d433b68.